### PR TITLE
part2_Mavropulo_Konstantin: Part2 has refactored due to demand

### DIFF
--- a/src/test/java/part2/exercise/CollectorsExercise1.java
+++ b/src/test/java/part2/exercise/CollectorsExercise1.java
@@ -9,6 +9,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.*;
+import java.util.stream.Collector;
 import java.util.stream.Stream;
 
 import static java.util.Comparator.comparingInt;
@@ -90,11 +91,14 @@ public class CollectorsExercise1 {
                                 e.getJobHistory().stream().mapToInt(
                                         JobHistoryEntry::getDuration).sum())
                 ))
-                .collect(toMap(
-                        Pair::getKey,
-                        Pair::getValue,
-                        (p1, p2) -> p1 + p2
-                ));
+                .collect(Collector.of(
+                        HashMap::new,
+                        (hm, p) -> hm.merge(p.getKey(), p.getValue(), Integer::sum),
+                        (hm1, hm2) -> {
+                            hm1.putAll(hm2);
+                            return hm1;
+                        }));
+
 
         Map<String, Integer> expected = ImmutableMap.<String, Integer>builder()
                 .put("John", 5 + 8 + 6 + 5 + 8 + 6 + 4 + 8 + 6 + 4 + 11 + 6 - 8 - 6)

--- a/src/test/java/part2/exercise/CollectorsExercise1.java
+++ b/src/test/java/part2/exercise/CollectorsExercise1.java
@@ -4,12 +4,14 @@ import com.google.common.collect.ImmutableMap;
 import data.Employee;
 import data.JobHistoryEntry;
 import data.Person;
+import javafx.util.Pair;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.*;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import static java.util.Comparator.comparingInt;
 import static java.util.stream.Collectors.*;
 
 public class CollectorsExercise1 {
@@ -17,7 +19,15 @@ public class CollectorsExercise1 {
     @Test
     public void testPersonToHisLongestJobDuration() {
 
-        Map<Person, Integer> collected = null;//getEmployees()
+        Map<Person, Integer> collected = getEmployees().stream()
+                .collect(toMap(
+                        Employee::getPerson,
+                        e -> e.getJobHistory()
+                                .stream()
+                                .map(JobHistoryEntry::getDuration)
+                                .max(comparingInt(d -> d))
+                                .orElse(null)
+                ));
 
         Map<Person, Integer> expected = ImmutableMap.<Person, Integer>builder()
                 .put(new Person("John", "Galt", 20), 3)
@@ -39,8 +49,15 @@ public class CollectorsExercise1 {
     @Test
     public void testPersonToHisTotalJobDuration() {
 
-        Map<Person, Integer> collected = null;
-
+        Map<Person, Integer> collected = getEmployees().stream()
+                .collect(toMap(
+                        Employee::getPerson,
+                        e -> e.getJobHistory()
+                                .stream()
+                                .map(JobHistoryEntry::getDuration)
+                                .reduce((a, d) -> a + d)
+                                .orElse(null)
+                ));
 
         Map<Person, Integer> expected = ImmutableMap.<Person, Integer>builder()
                 .put(new Person("John", "Galt", 20), 5)
@@ -61,10 +78,23 @@ public class CollectorsExercise1 {
     }
 
     @Test
-    public void testTotalJobDurationPerNameAndSurname(){
+    public void testTotalJobDurationPerNameAndSurname() {
 
         //Implement custom Collector
-        Map<String, Integer> collected = null;
+        Map<String, Integer> collected = getEmployees().stream()
+                .flatMap(e -> Stream.of(
+                        new Pair<>(e.getPerson().getFirstName(),
+                                e.getJobHistory().stream().mapToInt(
+                                        JobHistoryEntry::getDuration).sum()),
+                        new Pair<>(e.getPerson().getLastName(),
+                                e.getJobHistory().stream().mapToInt(
+                                        JobHistoryEntry::getDuration).sum())
+                ))
+                .collect(toMap(
+                        Pair::getKey,
+                        Pair::getValue,
+                        (p1, p2) -> p1 + p2
+                ));
 
         Map<String, Integer> expected = ImmutableMap.<String, Integer>builder()
                 .put("John", 5 + 8 + 6 + 5 + 8 + 6 + 4 + 8 + 6 + 4 + 11 + 6 - 8 - 6)


### PR DESCRIPTION
part2_Mavropulo_Konstantin:
🏹  Part2 has been refactored due to demand in request "part2_Mavropulo_Konstantin: Part2 has been completed. #33 completed" (with using Collectors.of instead of Collectors.map).